### PR TITLE
Draft: Implement basic Twitter bot functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Numainda is a Knowledge bot designed to engage and educate on Pakistan's rich le
    Create a `.env` file in the project root and add your Twitter and OpenAI API keys:
 
    ```plaintext
-   TWITTER_API_KEY=your_twitter_api_key
-   TWITTER_API_SECRET=your_twitter_api_secret
+   TWITTER_CONSUMER_KEY=your_twitter_consumer_key
+   TWITTER_CONSUMER_SECRET=your_twitter_consumer_secret
    TWITTER_ACCESS_TOKEN=your_access_token
    TWITTER_ACCESS_TOKEN_SECRET=your_access_token_secret
    OPENAI_API_KEY=your_openai_api_key

--- a/classes/twitter/__init__.py
+++ b/classes/twitter/__init__.py
@@ -1,42 +1,32 @@
 import os
-from requests_oauthlib import OAuth1Session
-import json
+import tweepy
 
 
-class Twitter:
-
+class TwitterBot:
     def __init__(self):
-        self.api_key = os.environ.get('CONSUMER_KEY')
-        self.api_secret = os.environ.get('CONSUMER_SECRET')
-        self.access_token = os.environ.get('ACCESS_TOKEN')
-        self.access_token_secret = os.environ.get('ACCESS_TOKEN_SECRET')
+        self.api = TwitterBot.authenticate()
+    
+    # Entry point for the Twitter bot
+    def start(self):
+        pass
+    
+    def authenticate() -> tweepy.API:
+        auth = tweepy.OAuthHandler(os.getenv('TWITTER_CONSUMER_KEY'), os.getenv('TWITTER_CONSUMER_SECRET'))
+        auth.set_access_token(os.getenv('TWITTER_ACCESS_TOKEN'), os.getenv('TWITTER_ACCESS_TOKEN'))
         
-        self.oauth = OAuth1Session(
-            self.api_key,
-            client_secret=self.api_secret,
-            resource_owner_key=self.access_token,
-            resource_owner_secret=self.access_token_secret
-        )
-
+        api = tweepy.API(auth)
+        
+        try:
+            api.verify_credentials()
+            print("Authentication was successful!")
+        except Exception as e:
+            print(f"Authentication failed: {e}")
+            
+        return api
+    
     def post_tweet(self, tweet):
-    # Twitter API v2 endpoint for posting tweets
-        url = 'https://api.twitter.com/2/tweets'
-
-
-        payload = {
-            'text': tweet
-        }
-
-        headers = {
-            'Content-Type': 'application/json'
-        }
-
-        print(json.dumps(payload))  # Optional: For debugging
-
-        response = self.oauth.post(url, headers=headers, data=json.dumps(payload))
-
-        if response.status_code == 201:  # Check for successful tweet creation
-            return response.json()
-        else:
-            print("Tweet failed:", response.text)
-            return None
+        self.api.update_status(tweet)
+        return True
+    
+    def get_all_mentions(self):
+        return self.api.mentions_timeline()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 requests-oauthlib==1.3.1
 openai==1.12.0
 streamlit==1.32.2
+tweepy==4.14.0
+python-dotenv===1.0.1

--- a/st_numainda.py
+++ b/st_numainda.py
@@ -3,6 +3,9 @@ import streamlit as st
 import time
 from classes.assistant import Assistant
 
+from dotenv import load_dotenv
+load_dotenv()
+   
 assistant_id = st.secrets["ASSISTANT_ID"]
 
 client = Assistant(openai_api_key=st.secrets["OPEN_AI_API_KEY"]).get_client()
@@ -26,7 +29,6 @@ st.markdown("""*Things You Can Ask Me:*
             
     * What happened in the parliament on 15th march 2024?
             """)
-
 
 if st.button("Start Chat"):
     st.session_state.start_chat = True


### PR DESCRIPTION
This commit introduces a preliminary draft for implementing the Twitter bot. Changes include:

- Adding a new method `respond_to_mentions` to the `TwitterBot` class, utilizing the `tweepy` API to fetch current mentions and respond to them using the ChatGPT API.
    
- Creation of `twitter_bot_service.py` containing the source code for running the bot.
    
- Updating the `start` method of the `TwitterBot` to execute a while loop every 5 minutes, invoking the `respond_to_mentions method`.

As mentioned in my previous pull request (#4) I have no way to actually test these changes since the ***Access Level*** for my current twitter API keys is not sufficient enough. Moreover I am also unaware as to how Numainda currently handles it interactions with the ChatGPT API and what instruction prompt it provides to it, so I have left that empty for now. 

Any suggestions/improvements would be appreciated!